### PR TITLE
Avoid redundant dimension updates in resize observer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -184,7 +184,11 @@ export default function RadialTreeExplorer({ data = sampleData, fitViewport = tr
     const ro = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const cr = entry.contentRect;
-        setDims({ width: cr.width, height: cr.height });
+        setDims((prev) =>
+          prev.width !== cr.width || prev.height !== cr.height
+            ? { width: cr.width, height: cr.height }
+            : prev
+        );
       }
     });
     ro.observe(el);


### PR DESCRIPTION
## Summary
- Prevent ResizeObserver callback from triggering state updates when dimensions are unchanged

## Testing
- `npm test` *(fails: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f11b9fc48332bd198e7842fd88e9